### PR TITLE
Fix watermark processing with no slices

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
@@ -42,6 +42,11 @@ public class WindowManager {
         if (this.lastWatermark == -1)
             this.lastWatermark = Math.max(0, watermarkTs - maxLateness);
 
+        if (this.aggregationStore.isEmpty()) {
+            this.lastWatermark = watermarkTs;
+            return new ArrayList<>();
+        }
+
         long oldestSliceStart = this.aggregationStore.getSlice(0).getTStart();
 
         if (this.lastWatermark < oldestSliceStart) {


### PR DESCRIPTION
Fixes #5. 

If no slices are present, the `WindowManager` will simply return an empty list when `processWatermark` is called.