### PR TITLE
Fix checkSliceEdges in SliceManager

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
@@ -93,7 +93,7 @@ public class SliceManager<InputType> {
                 long post = ((ShiftModification) mod).post;
                 int sliceIndex = this.aggregationStore.findSliceByEnd(pre);
                 if(sliceIndex==-1)
-                    return;
+                    continue;
                 Slice currentSlice = this.aggregationStore.getSlice(sliceIndex);
 
                 Slice.Type sliceType = currentSlice.getType();


### PR DESCRIPTION
Fix in checkSliceEdges to continue checking all WindowModifications in the set. Required for window types adding multiple modifications at once.