### PR TITLE
Kafka streams Scotty Transformer and Demo fix

### DIFF
--- a/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowOperator.java
+++ b/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowOperator.java
@@ -19,7 +19,7 @@ public class KeyedScottyWindowOperator<Key, Value> implements Processor<Key,Valu
     private MemoryStateFactory stateFactory;
     private HashMap<Key, SlicingWindowOperator<Value>> slicingWindowOperatorMap;
     private long lastWatermark;
-    private final AggregateFunction windowFunction;
+    private final AggregateFunction<Value, ?, ?> windowFunction;
     private final List<Window> windows;
     private long allowedLateness;
     private long watermarkEvictionPeriod = 100;

--- a/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowOperatorSupplier.java
+++ b/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowOperatorSupplier.java
@@ -1,0 +1,47 @@
+package de.tub.dima.scotty.kafkastreamsconnector;
+
+import de.tub.dima.scotty.core.windowFunction.AggregateFunction;
+import de.tub.dima.scotty.core.windowType.SlidingWindow;
+import de.tub.dima.scotty.core.windowType.TumblingWindow;
+import de.tub.dima.scotty.core.windowType.Window;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+
+public class KeyedScottyWindowOperatorSupplier<Key, Value> implements ProcessorSupplier<Key, Value> {
+
+  private final AggregateFunction<Value, ?, ?> windowFunction;
+  private final long allowedLateness;
+  private final List<Window> windows;
+
+  public KeyedScottyWindowOperatorSupplier(AggregateFunction<Value, ?, ?> windowFunction, long allowedLateness) {
+      this.windowFunction = windowFunction;
+      this.windows = new ArrayList<>();
+      this.allowedLateness = allowedLateness;
+  }
+
+  /**
+   * Register a new @{@link Window} definition that should be added to the Window Operator.
+   * For example {@link SlidingWindow} or {@link TumblingWindow}
+   *
+   * @param window the new window definition
+   */
+  public KeyedScottyWindowOperatorSupplier<Key, Value> addWindow(Window window) {
+      windows.add(window);
+      return this;
+  }
+  
+  @Override
+  public Processor<Key, Value> get() {
+    final KeyedScottyWindowOperator<Key, Value> processor =
+        new KeyedScottyWindowOperator<>(this.windowFunction, this.allowedLateness);
+
+    for (Window window : this.windows) {
+        processor.addWindow(window);
+    }
+
+    return processor;
+  }
+
+}

--- a/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformer.java
+++ b/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformer.java
@@ -18,12 +18,12 @@ import org.apache.kafka.streams.kstream.Transformer;
 public class KeyedScottyWindowTransformer<Key, Value, Result> extends KeyedScottyWindowOperator<Key, Value>  implements Transformer<Key, Value, Result>{
 
   public KeyedScottyWindowTransformer(AggregateFunction<Value, ?, ?> windowFunction, long allowedLateness) {
-    super(windowFunction, allowedLateness);
+      super(windowFunction, allowedLateness);
   }
   
   @Override
   public Result transform(Key key, Value value) {
-    this.process(key, value);
-    return null;
+      this.process(key, value);
+      return null;
   }
 }

--- a/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformer.java
+++ b/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformer.java
@@ -1,0 +1,29 @@
+package de.tub.dima.scotty.kafkastreamsconnector;
+
+import de.tub.dima.scotty.core.windowFunction.AggregateFunction;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Transformer;
+
+
+/**
+ * 
+ * Use the {@link KeyedScottyWindowOperator} as a transformer step in the Streams DSL.
+ * 
+ * @author bjoernv
+ *
+ * @param <Key> key type
+ * @param <Value> value type
+ * @param <Result> {@link KeyValue} return type (both key and value type can be set arbitrarily)
+ */
+public class KeyedScottyWindowTransformer<Key, Value, Result> extends KeyedScottyWindowOperator<Key, Value>  implements Transformer<Key, Value, Result>{
+
+  public KeyedScottyWindowTransformer(AggregateFunction<Value, ?, ?> windowFunction, long allowedLateness) {
+    super(windowFunction, allowedLateness);
+  }
+  
+  @Override
+  public Result transform(Key key, Value value) {
+    this.process(key, value);
+    return null;
+  }
+}

--- a/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformerSupplier.java
+++ b/kafkaStreams-connector/src/main/java/de/tub/dima/scotty/kafkastreamsconnector/KeyedScottyWindowTransformerSupplier.java
@@ -1,0 +1,47 @@
+package de.tub.dima.scotty.kafkastreamsconnector;
+
+import de.tub.dima.scotty.core.windowFunction.AggregateFunction;
+import de.tub.dima.scotty.core.windowType.SlidingWindow;
+import de.tub.dima.scotty.core.windowType.TumblingWindow;
+import de.tub.dima.scotty.core.windowType.Window;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+
+public class KeyedScottyWindowTransformerSupplier<Key, Value, Result> implements TransformerSupplier<Key, Value, Result> {
+
+  private final AggregateFunction<Value, ?, ?> windowFunction;
+  private final long allowedLateness;
+  private final List<Window> windows;
+
+  public KeyedScottyWindowTransformerSupplier(AggregateFunction<Value, ?, ?> windowFunction, long allowedLateness) {
+      this.windowFunction = windowFunction;
+      this.windows = new ArrayList<>();
+      this.allowedLateness = allowedLateness;
+  }
+  
+  /**
+   * Register a new @{@link Window} definition that should be added to the Window Operator.
+   * For example {@link SlidingWindow} or {@link TumblingWindow}
+   *
+   * @param window the new window definition
+   */
+  public KeyedScottyWindowTransformerSupplier<Key, Value, Result> addWindow(Window window) {
+      windows.add(window);
+      return this;
+  }
+  
+  @Override
+  public Transformer<Key, Value, Result> get() {
+    final KeyedScottyWindowTransformer<Key, Value, Result> processor =
+        new KeyedScottyWindowTransformer<>(this.windowFunction, this.allowedLateness);
+
+    for (Window window : this.windows) {
+        processor.addWindow(window);
+    }
+
+    return processor;
+  }
+
+}


### PR DESCRIPTION
1. **Implement Transformer Interface for KafkaStreams-Connector:** 
The KeyedScottyWindowOperator implements the Proccessor interface.
Therefore, it is only possible to call the .process(...) function from the Kafka Streams DSL, which is a terminating function.
Thus, it is not possible to do further computations on the stream.
With the new class, which implement the transformer interface, it is possible to call .transform(...) on the stream and do further computations.

2. **Add Supplier for Processor and Transformer and update demo:**
When the Kafka Streams Demo is started with more than one partition for the input topic, an exception occurs:
```
Exception in thread "SumDemo-a9a0abaf-52f6-4a7c-badb-64991c3fca28-StreamThread-1" java.lang.IllegalStateException: This should not happen as timestamp() should only be called while a record is processed
	at org.apache.kafka.streams.processor.internals.AbstractProcessorContext.timestamp(AbstractProcessorContext.java:158)
	at de.tub.dima.scotty.kafkastreamsconnector.KeyedScottyWindowOperator.process(KeyedScottyWindowOperator.java:46)
	at org.apache.kafka.streams.processor.internals.ProcessorNode.process(ProcessorNode.java:118)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:201)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:180)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:133)
	at org.apache.kafka.streams.processor.internals.SourceNode.process(SourceNode.java:87)
	at org.apache.kafka.streams.processor.internals.StreamTask.process(StreamTask.java:429)
	at org.apache.kafka.streams.processor.internals.AssignedStreamsTasks.process(AssignedStreamsTasks.java:474)
	at org.apache.kafka.streams.processor.internals.TaskManager.process(TaskManager.java:536)
	at org.apache.kafka.streams.processor.internals.StreamThread.runOnce(StreamThread.java:792)
	at org.apache.kafka.streams.processor.internals.StreamThread.runLoop(StreamThread.java:698)
	at org.apache.kafka.streams.processor.internals.StreamThread.run(StreamThread.java:671)
```
This happens, because only one `KeyedScottyWindowOperator` is created.
From the [docs](http://kafka.apache.org/28/javadoc/org/apache/kafka/streams/processor/ProcessorSupplier.html):
> The supplier should always generate a new instance each time get() gets called. Creating a single Processor object and returning the same object reference in get() would be a violation of the supplier pattern and leads to runtime exceptions.

Therefore, Suppliers are added for Processor and Transformer and are used in the demo to fix this issue.