### PR TITLE
Fix in StreamSlicer to emit combined separator 

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
@@ -71,7 +71,7 @@ public class StreamSlicer {
                 // Emit remaining separator if needed
                 if (min_next_edge_ts == te) {
                     if (flex_count > 0) {
-                        sliceManager.appendSlice(te, new Slice.Fixed());
+                        sliceManager.appendSlice(min_next_edge_ts, new Slice.Flexible(flex_count));
                     } else {
                         sliceManager.appendSlice(min_next_edge_ts, new Slice.Fixed());
                     }


### PR DESCRIPTION
`StreamSlicer` adds `new Slice.Flexible(flex_count)` which represents a combined separator. This reflects the slicing algorithm in the [Scotty paper from TODS 2021](https://dl.acm.org/doi/pdf/10.1145/3433675).
This closes https://github.com/TU-Berlin-DIMA/scotty-window-processor/issues/12.