### PR TITLE
Fix Bug ouf-of-order Processing

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
@@ -159,9 +159,15 @@ public class SliceManager<InputType> {
             if (mod instanceof AddModification) {
                 long newWindowEdge = ((AddModification) mod).post;
                 int sliceIndex = this.aggregationStore.findSliceIndexByTimestamp(newWindowEdge);
-                Slice slice = this.aggregationStore.getSlice(sliceIndex);
-                if(slice.getTStart() != newWindowEdge && slice.getTEnd() != newWindowEdge ){
-                    splitSlice(sliceIndex, ((AddModification) mod).post);
+                if(sliceIndex != -1) {
+                    Slice slice = this.aggregationStore.getSlice(sliceIndex);
+                    if (slice.getTStart() != newWindowEdge && slice.getTEnd() != newWindowEdge) {
+                        splitSlice(sliceIndex, ((AddModification) mod).post);
+                    }
+                }else {
+                    Slice sliceFirst = this.aggregationStore.getSlice(0);
+                    Slice newSlice = this.sliceFactory.createSlice(newWindowEdge, sliceFirst.getTStart(), 0, 0, sliceFirst.getType());
+                    this.aggregationStore.addSlice(0, newSlice);
                 }
             }
         }

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
@@ -63,7 +63,7 @@ public class SliceManager<InputType> {
 
         } else {
             // out of order
-            if(ts > windowManager.getMinAllowedTimestamp()) {
+            if(ts > Math.min(this.windowManager.getMinAllowedTimestamp(), this.aggregationStore.getSlice(0).getTStart())) {
 
                 for (WindowContext<InputType> windowContext : this.windowManager.getContextAwareWindows()) {
                     Set<WindowModifications> windowModifications = new HashSet<>();

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/SliceManager.java
@@ -63,24 +63,26 @@ public class SliceManager<InputType> {
 
         } else {
             // out of order
+            if(ts > windowManager.getMinAllowedTimestamp()) {
 
-            for (WindowContext<InputType> windowContext : this.windowManager.getContextAwareWindows()) {
-                Set<WindowModifications> windowModifications = new HashSet<>();
-                WindowContext.ActiveWindow assignedWindow = windowContext.updateContext(element, ts, windowModifications);
-                checkSliceEdges(windowModifications);
-            }
+                for (WindowContext<InputType> windowContext : this.windowManager.getContextAwareWindows()) {
+                    Set<WindowModifications> windowModifications = new HashSet<>();
+                    WindowContext.ActiveWindow assignedWindow = windowContext.updateContext(element, ts, windowModifications);
+                    checkSliceEdges(windowModifications);
+                }
 
-            // updateSlices(windowStarts);
+                // updateSlices(windowStarts);
 
-            int indexOfSlice = this.aggregationStore.findSliceIndexByTimestamp(ts);
-            this.aggregationStore.insertValueToSlice(indexOfSlice, element, ts);
-            if(this.windowManager.hasCountMeasure()){
-                // shift count in slices
-                for(; indexOfSlice<= this.aggregationStore.size()-2; indexOfSlice++) {
-                    LazySlice<InputType, ?> lazySlice = (LazySlice<InputType, ?>) this.aggregationStore.getSlice(indexOfSlice);
-                    StreamRecord<InputType> lastElement = lazySlice.dropLastElement();
-                    LazySlice<InputType, ?> nextSlice = (LazySlice<InputType, ?>) this.aggregationStore.getSlice(indexOfSlice + 1);
-                    nextSlice.prependElement(lastElement);
+                int indexOfSlice = this.aggregationStore.findSliceIndexByTimestamp(ts);
+                this.aggregationStore.insertValueToSlice(indexOfSlice, element, ts);
+                if (this.windowManager.hasCountMeasure()) {
+                    // shift count in slices
+                    for (; indexOfSlice <= this.aggregationStore.size() - 2; indexOfSlice++) {
+                        LazySlice<InputType, ?> lazySlice = (LazySlice<InputType, ?>) this.aggregationStore.getSlice(indexOfSlice);
+                        StreamRecord<InputType> lastElement = lazySlice.dropLastElement();
+                        LazySlice<InputType, ?> nextSlice = (LazySlice<InputType, ?>) this.aggregationStore.getSlice(indexOfSlice + 1);
+                        nextSlice.prependElement(lastElement);
+                    }
                 }
             }
         }

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
@@ -126,6 +126,11 @@ public class StreamSlicer {
             if (te >= newNextEdge)
                 flex_count++;
         }
+
+        if(this.windowManager.getMinAllowedTimestamp() == Long.MAX_VALUE){
+            this.windowManager.setMinAllowedTimestamp(te - this.windowManager.getMaxLateness());
+        }
+
         return flex_count;
     }
 

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
@@ -31,6 +31,7 @@ public class WindowManager {
     private long currentCount = 0;
     private long lastCount = 0;
     private boolean isSessionWindowCase;
+    private long minAllowedTimestamp = -1;
 
     public WindowManager(StateFactory stateFactory, AggregationStore aggregationStore) {
         this.stateFactory = stateFactory;
@@ -90,6 +91,7 @@ public class WindowManager {
 
         long maxDelay =  currentWatermark - maxFixedWindowSize;
         long removeFromTimestamp = Math.min(maxDelay, firstActiveWindowStart);
+        this.minAllowedTimestamp = removeFromTimestamp;
 
         this.aggregationStore.removeSlices(removeFromTimestamp);
     }
@@ -200,6 +202,10 @@ public class WindowManager {
     public void setMaxLateness(long maxLateness) {
         this.maxLateness = maxLateness;
     }
+
+    public long getMinAllowedTimestamp() { return this.minAllowedTimestamp; }
+
+    public void setMinAllowedTimestamp(long minAllowedTimestamp) { this.minAllowedTimestamp = minAllowedTimestamp; }
 
     public class AggregationWindowCollector implements WindowCollector, Iterable<AggregateWindow> {
 

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
@@ -31,7 +31,7 @@ public class WindowManager {
     private long currentCount = 0;
     private long lastCount = 0;
     private boolean isSessionWindowCase;
-    private long minAllowedTimestamp = -1;
+    private long minAllowedTimestamp = Long.MAX_VALUE;
 
     public WindowManager(StateFactory stateFactory, AggregationStore aggregationStore) {
         this.stateFactory = stateFactory;


### PR DESCRIPTION
Fixes https://github.com/TU-Berlin-DIMA/scotty-window-processor/issues/44  to not process out-of-order tuples outside of the allowed lateness (i.e. with a `timestamp < currentWatermark - maxLateness - maxFixedWindowSize`). 

Additional fix of same bug for out-of-order tuples outside of allowed lateness before any watermark occurred. Then, tuples with a `timestamp < startsTsOfFirstSlice` or `timestamp < timestampOfFirstTuple - maxLateness` are outside of allowed lateness and are discarded.

For context-ware windows (e.g. session window), a new slice is added with an addModification, if the out-of-order tuple is still in the allowed lateness and starts a new window.
