### PR TITLE
Out-of-order processing Demo and Workaround to resend Windows in Allowed Lateness

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/SlicingWindowOperator.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/SlicingWindowOperator.java
@@ -66,4 +66,6 @@ public class SlicingWindowOperator<InputType> implements WindowOperator<InputTyp
     public void setMaxLateness(long maxLateness) {
         windowManager.setMaxLateness(maxLateness);
     }
+
+    public void setResendWindowsInAllowedLateness(boolean resendWindowsInAllowedLateness) {this.windowManager.setResendWindowsInAllowedLateness(resendWindowsInAllowedLateness);}
 }

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/WindowManager.java
@@ -31,6 +31,7 @@ public class WindowManager {
     private long currentCount = 0;
     private long lastCount = 0;
     private boolean isSessionWindowCase;
+    private boolean resendWindowsInAllowedLateness;
 
     public WindowManager(StateFactory stateFactory, AggregationStore aggregationStore) {
         this.stateFactory = stateFactory;
@@ -200,6 +201,14 @@ public class WindowManager {
     public void setMaxLateness(long maxLateness) {
         this.maxLateness = maxLateness;
     }
+
+    public long getLastWatermark() { return this.lastWatermark; }
+
+    public void setLastWatermarkToAllowedLateness() { this.lastWatermark = this.lastWatermark - this.maxLateness; }
+
+    public void setResendWindowsInAllowedLateness(boolean resendWindowsInAllowedLateness) {this.resendWindowsInAllowedLateness = resendWindowsInAllowedLateness;}
+
+    public boolean getResendWindowsInAllowedLateness() {return this.resendWindowsInAllowedLateness;}
 
     public class AggregationWindowCollector implements WindowCollector, Iterable<AggregateWindow> {
 

--- a/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/AllowedLatenessArchitecture.md
+++ b/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/AllowedLatenessArchitecture.md
@@ -1,0 +1,41 @@
+# Allowed Lateness Architecture Document
+This document describes the current implementation of processing out-of-order tuples with regard to the allowed lateness in Scotty and the desired future state.
+Test cases are implemented in the OutOfOrderDemo class.
+
+**Allowed lateness** specifies how long a system stores window aggregates.
+In Scotty, maxLateness is default 1000, but can be set to an arbitrary value.
+
+## Goal:
+- When an out-of-order tuple arrives after the watermark but in the allowed lateness arrives, Scotty outputs the updated window aggregates with the next watermark
+
+## Current state:
+- When tuple in allowed lateness arrives, it is processed and added to the correct slice
+- It depends on the type of window, how updated window aggregates are output:
+
+### Context-free windows
+- Workaround: Function setResendWindowsInAllowedLateness in SlicingWindowOperator can be set to true
+- Scotty returns all windows from allowed lateness until lastWatermark again, **if** a tuple in allowed lateness has arrived, and, as always, returns all windows between lastWatermark and currentWatermark 
+- Problem: all window results from allowed lateness until lastWatermark are returned
+--> e.g., for tumbling and sliding windows ,many windows are triggered and their results are output again even though they did not change, which leads to performance issues
+- only the windows which were affected by the out-of-order tuple in the allowed lateness and have changes in their aggregation result should be output again
+- see tupleInAllowedLatenessTest
+
+### Context-aware windows - Example session window
+- With out-of-order tuple, session can be just updated (insert new tuple), session can be changed (extended, split, or merged with other session), or new session can be added (last case was fixed together with out-of-order bug PR #45, see out-of-order test cases in SessionWindowOperatorTest) 
+- currently, it works when a new session is added, i.e., an out-of-order tuple in allowed lateness arrives that creates a new session window (in Scotty see tupleInAllowedLatenessTestAddSession)
+--> because a new activeWindow is created and this is then returned whether or not it is between lastWatermark and currentWatermark 
+--> only returns the added window, exactly the target behaviour
+- Problem: in triggerWindows, all windows stored in windowContext are returned & then are removed from windowContext
+--> when session is updated/extended/split/merged, session is already removed from windowContext (see SessionWindow implementation triggerWindows) and can not be correctly updated
+- windowContext has to keep all windows in allowed lateness to enable changes, and should only be triggered when they changed due to an out-of-order tuple in allowed lateness
+- see tests tupleInAllowedLatenessTestUpdateSession and tupleInAllowedLatenessTestChangeSession
+
+## Todo: 
+- add logic that returns only window aggregations that have been updated due to tuple in allowed lateness
+- Need to know: which windows were updated/changed?
+- time-based tumbling or sliding window: only the window(s) to which the tuple in allowed lateness belongs
+--> just trigger these windows again
+- count-based tumbling or sliding window: all changed windows 
+--> need to know which windows were changed
+- complex for context-aware windows: allowed lateness tuple might change multiple windows 
+--> windowContext has to keep all windows in allowed lateness to enable changes of windows, and needs some indication whether window has been changed in allowed lateness and whether is has to be output again

--- a/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderArchitecture.md
+++ b/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderArchitecture.md
@@ -1,6 +1,6 @@
-# Allowed Lateness Architecture Document
+# Out-of-order Architecture Document - Allowed Lateness Implementation
 This document describes the current implementation of processing out-of-order tuples with regard to the allowed lateness in Scotty and the desired future state.
-Test cases are implemented in the OutOfOrderDemo class.
+Test cases are implemented in the [OutOfOrderDemo class](OutOfOrderDemo.java).
 
 **Allowed lateness** specifies how long a system stores window aggregates.
 In Scotty, maxLateness is default 1000, but can be set to an arbitrary value.
@@ -16,17 +16,17 @@ In Scotty, maxLateness is default 1000, but can be set to an arbitrary value.
 - Workaround: Function setResendWindowsInAllowedLateness in SlicingWindowOperator can be set to true
 - Scotty returns all windows from allowed lateness until lastWatermark again, **if** a tuple in allowed lateness has arrived, and, as always, returns all windows between lastWatermark and currentWatermark 
 - Problem: all window results from allowed lateness until lastWatermark are returned
---> e.g., for tumbling and sliding windows ,many windows are triggered and their results are output again even though they did not change, which leads to performance issues
+&rarr; e.g., for tumbling and sliding windows ,many windows are triggered and their results are output again even though they did not change, which leads to performance issues
 - only the windows which were affected by the out-of-order tuple in the allowed lateness and have changes in their aggregation result should be output again
-- see tupleInAllowedLatenessTest
+- see test case tupleInAllowedLatenessTest
 
 ### Context-aware windows - Example session window
 - With out-of-order tuple, session can be just updated (insert new tuple), session can be changed (extended, split, or merged with other session), or new session can be added (last case was fixed together with out-of-order bug PR #45, see out-of-order test cases in SessionWindowOperatorTest) 
 - currently, it works when a new session is added, i.e., an out-of-order tuple in allowed lateness arrives that creates a new session window (in Scotty see tupleInAllowedLatenessTestAddSession)
---> because a new activeWindow is created and this is then returned whether or not it is between lastWatermark and currentWatermark 
---> only returns the added window, exactly the target behaviour
+&rarr; because a new activeWindow is created and this is then returned whether or not it is between lastWatermark and currentWatermark 
+&rarr; only returns the added window, exactly the target behaviour
 - Problem: in triggerWindows, all windows stored in windowContext are returned & then are removed from windowContext
---> when session is updated/extended/split/merged, session is already removed from windowContext (see SessionWindow implementation triggerWindows) and can not be correctly updated
+&rarr; when session is updated/extended/split/merged, session is already removed from windowContext (see SessionWindow implementation triggerWindows) and can not be correctly updated
 - windowContext has to keep all windows in allowed lateness to enable changes, and should only be triggered when they changed due to an out-of-order tuple in allowed lateness
 - see tests tupleInAllowedLatenessTestUpdateSession and tupleInAllowedLatenessTestChangeSession
 
@@ -34,8 +34,8 @@ In Scotty, maxLateness is default 1000, but can be set to an arbitrary value.
 - add logic that returns only window aggregations that have been updated due to tuple in allowed lateness
 - Need to know: which windows were updated/changed?
 - time-based tumbling or sliding window: only the window(s) to which the tuple in allowed lateness belongs
---> just trigger these windows again
+&rarr; just trigger these windows again
 - count-based tumbling or sliding window: all changed windows 
---> need to know which windows were changed
+&rarr; need to know which windows were changed
 - complex for context-aware windows: allowed lateness tuple might change multiple windows 
---> windowContext has to keep all windows in allowed lateness to enable changes of windows, and needs some indication whether window has been changed in allowed lateness and whether is has to be output again
+&rarr; windowContext has to keep all windows in allowed lateness to enable changes of windows, and needs some indication whether window has been changed in allowed lateness and whether is has to be output again

--- a/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderDemo.java
+++ b/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderDemo.java
@@ -1,0 +1,132 @@
+package de.tub.dima.scotty.slicing.aggregationstore.test;
+
+import de.tub.dima.scotty.core.AggregateWindow;
+import de.tub.dima.scotty.core.windowFunction.ReduceAggregateFunction;
+import de.tub.dima.scotty.core.windowType.*;
+import de.tub.dima.scotty.slicing.SlicingWindowOperator;
+import de.tub.dima.scotty.slicing.aggregationstore.test.windowTest.WindowAssert;
+import de.tub.dima.scotty.state.memory.MemoryStateFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class OutOfOrderDemo {
+
+    private SlicingWindowOperator<Integer> slicingWindowOperator;
+    private MemoryStateFactory stateFactory;
+
+    @Before
+    public void setup() {
+        this.stateFactory = new MemoryStateFactory();
+        this.slicingWindowOperator = new SlicingWindowOperator<Integer>(stateFactory);
+        this.slicingWindowOperator.setResendWindowsInAllowedLateness(true);
+    }
+
+    @Test
+    public void simpleOutOfOrderTest() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new TumblingWindow(WindowMeasure.Time, 10));
+
+        slicingWindowOperator.processElement(1, 2000);
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 2605);
+        // tuple is in order, because tuple before has lower timestamp 2800 > 2605
+        slicingWindowOperator.processElement(1, 2800);
+        // tuple is out-of-order, because the tuple before has a greater timestamp 2400 < 2800
+        slicingWindowOperator.processElement(1, 2400);
+        slicingWindowOperator.processElement(1, 3700);
+        // watermark indicates that no tuple with timestamp lower than 3000 will arrive
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(3000);
+
+        // Scotty outputs all windows that ended before watermark 3000 starting from watermark - maxlateness (3000-1000)
+        WindowAssert.assertContains(resultWindows, 2000, 2010, 1);
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 2);
+        WindowAssert.assertContains(resultWindows, 2800, 2810, 1);
+        WindowAssert.assertContains(resultWindows, 2400, 2410, 1);
+    }
+
+
+    @Test
+    public void tupleInAllowedLatenessTest() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new TumblingWindow(WindowMeasure.Time, 10));
+
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 2800);
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(3000);
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
+        // tuple in allowed lateness
+        slicingWindowOperator.processElement(1, 2605);
+        slicingWindowOperator.processElement(1,3010);
+        resultWindows = slicingWindowOperator.processWatermark(3100);
+
+        // output changed window result
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 2);
+        WindowAssert.assertContains(resultWindows, 3010, 3020, 1);
+    }
+
+    @Test
+    public void tupleInAllowedLatenessTestUpdateSession() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new SessionWindow(WindowMeasure.Time, 10));
+
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 2800);
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(3000);
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
+        //tuple in allowed lateness
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 3010);
+        resultWindows = slicingWindowOperator.processWatermark(3100);
+
+        // output updated session
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 2);
+    }
+
+    /*@Test
+    public void tupleInAllowedLatenessTestChangeSession() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new SessionWindow(WindowMeasure.Time, 10));
+
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 2800);
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(3000);
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
+        //tuple in allowed lateness
+        slicingWindowOperator.processElement(1, 2605);
+        slicingWindowOperator.processElement(1, 3010);
+        resultWindows = slicingWindowOperator.processWatermark(3100);
+
+        // output changed session
+        WindowAssert.assertContains(resultWindows, 2600, 2615, 2);
+        WindowAssert.assertContains(resultWindows, 3010, 3020, 1);
+    }*/
+
+
+
+    @Test
+    public void tupleInAllowedLatenessTestAddSession() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new SessionWindow(WindowMeasure.Time, 10));
+
+        slicingWindowOperator.processElement(1, 2600);
+        slicingWindowOperator.processElement(1, 2800);
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(3000);
+        WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
+        // tuple in allowed lateness
+        // this tuple should add a new session window
+        slicingWindowOperator.processElement(1, 2500);
+        slicingWindowOperator.processElement(1, 3010);
+        resultWindows = slicingWindowOperator.processWatermark(3100);
+
+        Assert.assertTrue(resultWindows.size() == 2);
+        WindowAssert.assertContains(resultWindows, 2500, 2510, 1); // added new session
+        //WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
+        //WindowAssert.assertContains(resultWindows, 2800, 2810, 1);
+        WindowAssert.assertContains(resultWindows, 3010, 3020, 1);
+    }
+
+
+}

--- a/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderDemo.java
+++ b/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/OutOfOrderDemo.java
@@ -59,6 +59,9 @@ public class OutOfOrderDemo {
         WindowAssert.assertContains(resultWindows, 3800, 3810, 2);
     }
 
+    /* Tests for Allowed Lateness Implementation
+    * see OutOfOrderArchitecture.md
+    */
 
     @Test
     public void tupleInAllowedLatenessTest() {


### PR DESCRIPTION
Implements test cases to demonstrate out-of-order processing and adds architecture document for processing out-of-order tuples in allowed lateness.

Implements workaround to return windows from allowed lateness until lastWatermark again, **if** an out-of-order tuple in allowed lateness has arrived.
Variable `resendWindowsInAllowedLateness` can be set to true by function `setResendWindowsInAllowedLateness` in SlicingWindowOperator at initialization.
Upon the arrival of an out-of-order tuple in allowed lateness, lastWatermark is set to allowed lateness.