### PR TITLE
Fix slicing start stream slicer

### DIFF
--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
@@ -102,7 +102,7 @@ public class StreamSlicer {
 
     private long calculateNextFixedEdge(long te) {
         // next_edge will be the last edge
-        long current_min_edge = min_next_edge_ts == Long.MIN_VALUE ? Long.MAX_VALUE : min_next_edge_ts;
+        long current_min_edge = min_next_edge_ts == Long.MIN_VALUE ? 0 : min_next_edge_ts;
         long t_c = Math.max(te - this.windowManager.getMaxLateness(), current_min_edge);
         long edge = Long.MAX_VALUE;
         for (ContextFreeWindow tw : this.windowManager.getContextFreeWindows()) {

--- a/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
+++ b/slicing/src/main/java/de/tub/dima/scotty/slicing/StreamSlicer.java
@@ -116,8 +116,12 @@ public class StreamSlicer {
     }
 
     private int calculateNextFlexEdge(long te) {
-        // next_edge will be the last edge
-        long t_c = Math.max(this.maxEventTime, min_next_edge_ts);
+        long t_c;
+        if (min_next_edge_ts == Long.MIN_VALUE){ // if no fixed windows min_next_edge stays default value
+            t_c = this.maxEventTime;
+        }else {
+            t_c = Math.min(this.maxEventTime, min_next_edge_ts); // take next smallest window edge
+        }
         long edge = Long.MAX_VALUE;
         int flex_count = 0;
         for (WindowContext cw : this.windowManager.getContextAwareWindows()) {

--- a/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/windowTest/SlidingWindowOperatorTest.java
+++ b/slicing/src/test/java/de/tub/dima/scotty/slicing/aggregationstore/test/windowTest/SlidingWindowOperatorTest.java
@@ -231,5 +231,35 @@ public class SlidingWindowOperatorTest {
         WindowAssert.assertContains(resultWindows, 2600, 2610, 1);
     }
 
+    @Test
+    public void slicingStartTest() {
+        slicingWindowOperator.addWindowFunction((ReduceAggregateFunction<Integer>) (currentAggregate, element) -> currentAggregate + element);
+        slicingWindowOperator.addWindowAssigner(new SlidingWindow(WindowMeasure.Time, 10, 4));
+
+        slicingWindowOperator.processElement(1, 1);
+        slicingWindowOperator.processElement(1, 10);
+        slicingWindowOperator.processElement(1, 11);
+        slicingWindowOperator.processElement(1, 12);
+        slicingWindowOperator.processElement(1, 13);
+        slicingWindowOperator.processElement(1, 14);
+        slicingWindowOperator.processElement(1, 15);
+        slicingWindowOperator.processElement(3, 19);
+        slicingWindowOperator.processElement(4, 29);
+        slicingWindowOperator.processElement(5, 36);
+
+        List<AggregateWindow> resultWindows = slicingWindowOperator.processWatermark(22);
+
+        WindowAssert.assertContains(resultWindows, 0, 10, 1);
+        WindowAssert.assertContains(resultWindows, 4, 14, 4);
+        WindowAssert.assertContains(resultWindows, 8, 18, 6);
+        WindowAssert.assertContains(resultWindows, 12, 22, 7);
+
+        resultWindows = slicingWindowOperator.processWatermark(55);
+        WindowAssert.assertContains(resultWindows, 16, 26, 3);
+        WindowAssert.assertContains(resultWindows, 20, 30, 4);
+        WindowAssert.assertContains(resultWindows, 24, 34, 4);
+        WindowAssert.assertContains(resultWindows, 28, 38, 9);
+        WindowAssert.assertContains(resultWindows, 32, 42, 5);
+    }
 
 }


### PR DESCRIPTION
Fixes https://github.com/TU-Berlin-DIMA/scotty-window-processor/issues/50 in StreamSlicer to avoid getting stuck in loop.
Additional fix in `calculateNextFlexEdge` was required to enable correct results for combining tumbling and session windows (see Test `outOfOrderCombinedSessionTumblingMegeSession`).