### PR TITLE
Fix pom for maven release

### DIFF
--- a/core/src/main/java/stream/scotty/core/windowType/PunctuationWindow.java
+++ b/core/src/main/java/stream/scotty/core/windowType/PunctuationWindow.java
@@ -13,7 +13,7 @@ public class PunctuationWindow implements ForwardContextFree {
     /**
      * the measure of the Punctuation Window is time
      * @param punctuation defines how the punctuation tuple looks like
-     * @see stream.scotty.slicing.aggregationstore.test.windowTest.PunctuationWindowTest
+     * stream.scotty.slicing.aggregationstore.test.windowTest.PunctuationWindowTest
      * and stream.scotty.slicing.aggregationstore.test.windowTest.PunctuationWindowTupleTest
      * for examples for punctuations
      */

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -264,7 +267,7 @@
 
         </profile>
     </profiles>
-    <build>
+    <!--<build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -284,7 +287,7 @@
                 </executions>
             </plugin>
         </plugins>
-    </build>
+    </build>-->
 
 
 </project>

--- a/slicing/src/main/java/stream/scotty/slicing/aggregationstore/AggregationStore.java
+++ b/slicing/src/main/java/stream/scotty/slicing/aggregationstore/AggregationStore.java
@@ -26,7 +26,7 @@ public interface AggregationStore<InputType> {
      * Returns slice for a given index or @{@link IndexOutOfBoundsException}
      *
      * @param index >= 0 < size
-     * @return @Slice
+     * @return Slice
      */
     Slice<InputType, ?> getSlice(int index);
 


### PR DESCRIPTION
Fix pom to enable generating javadocs for Maven release (Issue #41):
Turn off doclint in pom to enable creating javadocs without errors

Fix some errors in javadocs